### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/albums-api/Controllers/UnsecuredController.cs
+++ b/albums-api/Controllers/UnsecuredController.cs
@@ -10,6 +10,12 @@ namespace UnsecureApp.Controllers
 
         public string ReadFile(string userInput)
         {
+            // Validate user input
+            if (userInput.Contains("..") || userInput.Contains("/") || userInput.Contains("\\"))
+            {
+                return "Invalid path";
+            }
+
             using (FileStream fs = File.Open(userInput, FileMode.Open))
             {
                 byte[] b = new byte[1024];


### PR DESCRIPTION
Fixes [https://github.com/geovanams/demoGHAS/security/code-scanning/1](https://github.com/geovanams/demoGHAS/security/code-scanning/1)

To fix the problem, we need to validate the `userInput` before using it to construct a file path. We will ensure that the `userInput` does not contain any path separators or parent directory references. This can be done by checking for the presence of "..", "/", or "\\" in the input and rejecting it if any are found.

1. Add a validation check for `userInput` to ensure it does not contain "..", "/", or "\\".
2. If the validation fails, return an appropriate error message or handle the error as needed.
3. If the validation passes, proceed with the file operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
